### PR TITLE
fix: Toolwindow icon in light theme and new ui outline

### DIFF
--- a/src/main/resources/icons/toolwindow_dark.svg
+++ b/src/main/resources/icons/toolwindow_dark.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" fill="none" stroke="#6C707E" stroke-linecap="round" stroke-linejoin="round" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="16" fill="none" stroke="#CED0D6" stroke-linecap="round" stroke-linejoin="round" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
  <path d="m2.7698 14.289h4.9544l0.82381 2.511 3.0714-9.3618 2.498 7.6138 1.0767-0.8794 1.3119 1.0715h4.8496" fill="none" stroke-linecap="round" stroke-linejoin="miter" stroke-width="1"/>
  <path d="m4.4522 3.0202h14.92c0.95376 0 1.5479 0.76652 1.7216 1.6837 0.85753 4.5295 1.3186 9.2137 0 14.592-0.22238 0.90706-0.76782 1.6837-1.7216 1.6837h-14.92c-0.95375 0-1.569-0.76294-1.7216-1.6837-0.85371-5.1524-0.87599-10.024 0-14.592 0.1758-0.91679 0.76782-1.6837 1.7216-1.6837z" stroke-width="1"/>
 </svg>


### PR DESCRIPTION
The current toolwindow icon is barely visible when using a light theme, and the reason is that it seems to be a dark variant.

![image](https://github.com/JetBrains/HotSpotCrashExaminerPlugin/assets/803621/1af872f0-b54a-4527-b480-a1a02eabe444)

This PR tweaks the icon so that it is visible in the light mode.

![image](https://github.com/JetBrains/HotSpotCrashExaminerPlugin/assets/803621/18774874-e91a-4045-9925-57bf5ea4786d)


Also, the stroke colors have been changed to match the recommended NewUI colors, see :

https://github.com/JetBrains/intellij-sdk-docs/blob/e0ea6d0cc2d442ea68b866487199483a8da36d8c/topics/reference_guide/icons.md?plain=1#L288-L306